### PR TITLE
feat: errorHandling can be set to warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ module.exports = {
         // OPTIONAL
         // Sets the file extension
         ext: ".json",
+
+        // OPTIONAL
+        // If something goes wrong while downloading the remote file,
+        // report a warning instead of stopping the build. (default: "fail")
+        errorHandling: "warn",
       },
     },
   ],


### PR DESCRIPTION
This option will allow the Gatsby build to continue even if an error occurs while downloading a remote file.